### PR TITLE
Found some events which has usefully  'unexpected' SystemAddresses ( according to docs )

### DIFF
--- a/EliteJournalReader/Events/SupercruiseEntryEvent.cs
+++ b/EliteJournalReader/Events/SupercruiseEntryEvent.cs
@@ -16,6 +16,7 @@ namespace EliteJournalReader.Events
 
         public class SupercruiseEntryEventArgs : JournalEventArgs
         {
+            public long SystemAddress { get; set; }
             public string StarSystem { get; set; }
         }
     }

--- a/EliteJournalReader/Events/SupercruiseExitEvent.cs
+++ b/EliteJournalReader/Events/SupercruiseExitEvent.cs
@@ -19,6 +19,7 @@ namespace EliteJournalReader.Events
 
         public class SupercruiseExitEventArgs : JournalEventArgs
         {
+            public long  SystemAddress { get; set; }
             public string StarSystem { get; set; }
             public string Body { get; set; }
             public long BodyID { get; set; }

--- a/EliteJournalReader/JournalEvent.cs
+++ b/EliteJournalReader/JournalEvent.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 
 namespace EliteJournalReader
 {
@@ -35,10 +37,37 @@ namespace EliteJournalReader
         internal override JournalEventArgs FireEvent(object sender, JObject evt)
         {
             var eventArgs = evt.ToObject<TJournalEventArgs>();
+
             eventArgs.OriginalEvent = evt;
             eventArgs.Timestamp = DateTime.Parse(evt.Value<string>("timestamp"),
                 CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
+#if true
+            Type argsType = typeof(TJournalEventArgs);
+            var eventName = evt["event"];
+
+            var argsPropertyNames = argsType.GetProperties().Select(p => p.Name).ToList();
+            string[] ignoreProperties=new string[]{"event"};
+            foreach (var jProperty in evt.Properties())
+            {
+                var jsonPropertyName = jProperty.Name;
+                if (ignoreProperties.Contains(jsonPropertyName))
+                {
+                    // ignore anything in the ignore list
+                }
+                else if (jsonPropertyName.EndsWith("_Localised",StringComparison.CurrentCultureIgnoreCase))
+                {
+                    // ignore localised
+                } 
+                else if (!argsPropertyNames.Any(x=>string.Compare(jsonPropertyName,x,StringComparison.InvariantCultureIgnoreCase)==0))
+                {
+                    // found something missing
+                    Trace.TraceInformation($"EventArgs for {eventName} does not contain property {jsonPropertyName}");
+                    //Debugger.Break();
+                }
+
+            }
+#endif
             eventArgs.PostProcess(evt);
 
             Fired?.Invoke(sender, eventArgs);

--- a/EliteJournalReader/JournalEvent.cs
+++ b/EliteJournalReader/JournalEvent.cs
@@ -42,7 +42,7 @@ namespace EliteJournalReader
             eventArgs.Timestamp = DateTime.Parse(evt.Value<string>("timestamp"),
                 CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
-#if true
+#if DEBUG
             Type argsType = typeof(TJournalEventArgs);
             var eventName = evt["event"];
 


### PR DESCRIPTION
Found in the wild in real journal files and populated correctly - but not in the v25 documentation

Modification to JournalEvent to detect json properties in events which aren't in the corresponding eventArgs
- because where I have found one there may be more :D
- you might not want to include the JournalEvent change in production but provided as a courtesy.
